### PR TITLE
Remove custom text from the LICENSE for GitHub to recognize it

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-Unless otherwise noted in a LICENSE file for specific files or directories, the files in this repository are under the following license.
-
 The MIT License (MIT)
 
 Copyright (c) 2016 HERE Europe B.V.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,15 @@ This repository holds a series of code examples demonstrating the use of JavaScr
 
 > **You do not need to clone this repository, just use the links below to navigate to [jsfiddle.net](http://jsfiddle.net)**.
 
-See the [LICENSE](LICENSE) file in the root of this project for license details.
-
 Examples for the following APIs are available within this repository:
 
 * [Data Lens](https://datalens.here.com)
 * [Maps API for JavaScript 3.x](https://developer.here.com/develop/javascript-api)
+
+
+## License
+
+Unless otherwise noted in `LICENSE` files for specific files or directories, the [LICENSE](LICENSE) in the root applies to all content in this repository.
 
 
 ## Data Lens


### PR DESCRIPTION
Move the text to the README.md file instead.